### PR TITLE
Change the ownership of `BO4E-Schemas`

### DIFF
--- a/src/bost/pull.py
+++ b/src/bost/pull.py
@@ -16,7 +16,7 @@ from bost.config import Config
 from bost.logger import logger
 from bost.schema import Object, Reference, SchemaRootType, StrEnum
 
-OWNER = "Hochfrequenz"
+OWNER = "BO4E"
 REPO = "BO4E-Schemas"
 TIMEOUT = 10  # in seconds
 


### PR DESCRIPTION
Note that this is not critical as GitHub has a redirection from `Hochfrequenz`. But it's nicer without redirection in my thinking. Maybe it prevents some weird interactions in the future as well.